### PR TITLE
hotfix: fix release workflow for production images

### DIFF
--- a/.github/workflows/build_service.yml
+++ b/.github/workflows/build_service.yml
@@ -51,7 +51,7 @@ jobs:
         if: inputs.image-tag != ''
         uses: docker/build-push-action@v3
         with:
-          context: ${{ inputs.path }}
+          context: ${{ inputs.context }}
           file: ${{ inputs.path }}/Dockerfile
           push: true
           tags: ghcr.io/kioku-project/${{ inputs.image-name }}:${{ inputs.image-tag }}


### PR DESCRIPTION
The `build_service` workflow distinguishes if a tag is given to it or not.
If the tag is not specified, it will be generated from the branch name. During testing, only this job was looked at and the mistake of the other job, that could not be executed was overlooked.
Before the context was wrongly set to the path of the Dockerfile.
With this, it will be fixed.