### PR TITLE
unit testing infrastructure

### DIFF
--- a/.github/workflows/build_service.yml
+++ b/.github/workflows/build_service.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set outputs
         id: vars

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -19,13 +19,12 @@ jobs:
           cd backend
           go test -json ./... > report.json
           go test -coverprofile=coverage.out ./...
-          cd ..
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: backend
-          args: >
+          args: >-
             -X
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
@@ -40,7 +39,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: frontend
-          args: >
+          args: >-
             -X
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -1,0 +1,47 @@
+name: SonarScan
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  GOLANG_PROTOBUF_REGISTRATION_CONFLICT: ignore
+
+jobs:
+  sonarcloud-backend:
+    name: SonarCloud Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run golang tests
+        run: |
+          cd backend
+          go test -json ./... > report.json
+          go test -coverprofile=coverage.out ./...
+          cd ..
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: backend
+          args: >
+            -X
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+  sonarcloud-frontend:
+    name: SonarCloud Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: frontend
+          args: >
+            -X
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}

--- a/backend/services/user/handler/user_test.go
+++ b/backend/services/user/handler/user_test.go
@@ -3,14 +3,14 @@ package handler_test
 import (
 	"testing"
 
-	pbcollab "github.com/kioku-project/kioku/services/collaboration/proto"
+	pbCollaboration "github.com/kioku-project/kioku/services/collaboration/proto"
 	"github.com/kioku-project/kioku/services/user/handler"
 	"github.com/kioku-project/kioku/store"
 )
 
 func TestUser(t *testing.T) {
 	var mockUserStore store.UserStore
-	var mockCollaborationService pbcollab.CollaborationService
+	var mockCollaborationService pbCollaboration.CollaborationService
 
 	userService := handler.New(mockUserStore, mockCollaborationService)
 

--- a/backend/services/user/handler/user_test.go
+++ b/backend/services/user/handler/user_test.go
@@ -1,0 +1,20 @@
+package handler_test
+
+import (
+	"testing"
+
+	pbcollab "github.com/kioku-project/kioku/services/collaboration/proto"
+	"github.com/kioku-project/kioku/services/user/handler"
+	"github.com/kioku-project/kioku/store"
+)
+
+func TestUser(t *testing.T) {
+	var mockUserStore store.UserStore = nil
+	var mockCollaborationService pbcollab.CollaborationService = nil
+
+	userService := handler.New(mockUserStore, mockCollaborationService)
+
+	if userService == nil {
+		t.Errorf("Received invalid User Service\n")
+	}
+}

--- a/backend/services/user/handler/user_test.go
+++ b/backend/services/user/handler/user_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	var mockUserStore store.UserStore = nil
-	var mockCollaborationService pbcollab.CollaborationService = nil
+	var mockUserStore store.UserStore
+	var mockCollaborationService pbcollab.CollaborationService
 
 	userService := handler.New(mockUserStore, mockCollaborationService)
 

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.projectName=Kioku Backend
 sonar.projectVersion=1.0
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**
+sonar.exclusions=**/*_test.go,**/vendor/**,**/*.pb.go,**/*.pb.micro.go,**/services/**/main.go
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -1,0 +1,22 @@
+
+# =====================================================
+#   Standard properties
+# =====================================================
+sonar.organization=kioku-project
+sonar.projectKey=kioku-project_kioku_services
+sonar.projectName=Kioku Backend
+sonar.projectVersion=1.0
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
+
+# =====================================================
+#   Properties specific to Go
+# =====================================================
+
+sonar.go.tests.reportPaths=report.json
+sonar.go.coverage.reportPaths=coverage.out

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,0 +1,17 @@
+
+# =====================================================
+#   Standard properties
+# =====================================================
+sonar.organization=kioku-project
+sonar.projectKey=kioku-project_kioku_frontend
+sonar.projectName=Kioku Frontend
+sonar.projectVersion=1.0
+
+sonar.sources=.
+
+
+# =====================================================
+#   Typescript specific properties
+# =====================================================
+
+sonar.typescript.tsconfigPaths=.


### PR DESCRIPTION
This PR adds a dummy service unit test to kick off the unit testing infrastructure.

> **Warning**
> Before this can be merges without problems a few things must be done in SonarCloud after these changes got reviewed

1. ✅Delete existing Sonarcloud project (existing project can exist without interfering)
2. ✅create new Sonarcloud project with "monorepo support"
3. ✅adapt Quality Gates for both projects
4. ✅add `SONAR_TOKEN_FRONTEND` and `SONAR_TOKEN_BACKEND` respectively in GitHub Secrets