### PR TITLE
fixed cardDelete when revlogs exist

### DIFF
--- a/backend/pkg/model/card.go
+++ b/backend/pkg/model/card.go
@@ -12,6 +12,7 @@ type Card struct {
 	FirstCardSideID string            `gorm:"not null"`
 	CardSides       []CardSide        `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	UserBindings    []UserCardBinding `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Revlogs         []Revlog          `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }
 
 func (c *Card) BeforeCreate(db *gorm.DB) (err error) {


### PR DESCRIPTION
This PR fixes an error where a card could not be deleted once learned because the database was unhappy with the reference of revlogs to a cardID that would no longer exist. I fixed this by cascade deleting revlog entries for a card when it is deleted.