### PR TITLE
Add kioku-maintainer as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @kioku-project/kioku-maintainer 


### PR DESCRIPTION
## Description

This pr adds the @kioku-project/kioku-maintainer team as `CODEOWNERS`
