### PR TITLE
Fix infinite loading

### DIFF
--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -14,6 +14,7 @@ import { Text } from "../components/Text";
 import { FormButton } from "../components/form/FormButton";
 import { InputField } from "../components/form/InputField";
 import { loadCatalog } from "./_app";
+import { checkAccessTokenValid } from "@/util/reauth";
 
 const inter = Inter({
 	weight: ["200", "400"],
@@ -42,7 +43,7 @@ export default function Page() {
 	const { _ } = useLingui();
 
 	useEffect(() => {
-		if (hasCookie("access_token")) {
+		if (checkAccessTokenValid()) {
 			router.push("/");
 		}
 	}, []);

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,6 +1,5 @@
 import { Trans, msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
-import { hasCookie } from "cookies-next";
 import { GetStaticProps } from "next";
 import { Inter } from "next/font/google";
 import Head from "next/head";

--- a/frontend/util/reauth.ts
+++ b/frontend/util/reauth.ts
@@ -12,18 +12,23 @@ export async function reauth(): Promise<boolean> {
 	return answ.status === 200;
 }
 
-export async function authedFetch(
-	input: RequestInfo | URL,
-	init?: RequestInit | undefined
-) {
+export function checkAccessTokenValid() {
 	if (!hasCookie("access_token")) {
-		if (!(await reauth())) {
-			return;
-		}
+		return false
 	}
 	const accessToken = getCookie("access_token");
 	const decoded = jwtDecode<JwtPayload>(accessToken!.toString());
 	if (!decoded.exp || decoded.exp > Math.floor(Date.now() / 1000)) {
+		return false
+	}
+	return true
+}
+
+export async function authedFetch(
+	input: RequestInfo | URL,
+	init?: RequestInit | undefined
+) {
+	if (!checkAccessTokenValid()) {
 		await reauth();
 	}
 	const answ = await fetch(input, {


### PR DESCRIPTION

## Description

This PR fixes the infite loading that occured when a user has an access token that is invalid.
Since the login site only checked for the existence of an acces token, it would redirect the user to the logged in application, which would redirect them back to the login page because the token was invalid.


## Resolved Issues
resolves #179

