### PR TITLE
Change path order in backend to fix invite and request endpoints

### DIFF
--- a/backend/api-documentation/groups/decline invitation.bru
+++ b/backend/api-documentation/groups/decline invitation.bru
@@ -1,11 +1,11 @@
 meta {
-  name: leave group
+  name: decline invitation
   type: http
-  seq: 12
+  seq: 13
 }
 
 delete {
-  url: {{baseUrl}}/api/groups/{{groupID}}/members
+  url: {{baseUrl}}/api/groups/{{groupID}}/members/request
   body: none
   auth: bearer
 }

--- a/backend/api-documentation/groups/decline request.bru
+++ b/backend/api-documentation/groups/decline request.bru
@@ -1,0 +1,21 @@
+meta {
+  name: decline request
+  type: http
+  seq: 14
+}
+
+delete {
+  url: {{baseUrl}}/api/groups/{{groupID}}/members/invitation
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+body:json {
+  {
+    "invitedUserEmail": "test@test.de"
+  }
+}

--- a/backend/api-documentation/groups/delete group.bru
+++ b/backend/api-documentation/groups/delete group.bru
@@ -1,7 +1,7 @@
 meta {
   name: delete group
   type: http
-  seq: 13
+  seq: 11
 }
 
 delete {

--- a/backend/api-documentation/groups/modify group.bru
+++ b/backend/api-documentation/groups/modify group.bru
@@ -1,7 +1,7 @@
 meta {
   name: modify group
   type: http
-  seq: 10
+  seq: 9
 }
 
 put {

--- a/backend/api-documentation/groups/promote or demote.bru
+++ b/backend/api-documentation/groups/promote or demote.bru
@@ -1,7 +1,7 @@
 meta {
   name: promote or demote
   type: http
-  seq: 11
+  seq: 10
 }
 
 put {

--- a/backend/services/frontend/main.go
+++ b/backend/services/frontend/main.go
@@ -116,6 +116,8 @@ func main() {
 	app.Put("/api/groups/:groupID", svc.ModifyGroupHandler)
 	app.Delete("/api/groups/:groupID", svc.DeleteGroupHandler)
 
+	app.Get("/api/groups/:groupID/members", svc.GetGroupMembersHandler)
+	app.Delete("/api/groups/:groupID/members", svc.LeaveGroupHandler)
 	app.Get("/api/groups/:groupID/members/requests", svc.GetGroupMemberRequestsHandler)
 	app.Get("/api/groups/:groupID/members/invitations", svc.GetInvitationsForGroupHandler)
 	app.Post("/api/groups/:groupID/members/invitation", svc.AddUserGroupInviteHandler)
@@ -123,8 +125,6 @@ func main() {
 	app.Post("/api/groups/:groupID/members/request", svc.AddUserGroupRequestHandler)
 	app.Delete("/api/groups/:groupID/members/request", svc.RemoveUserGroupRequestHandler)
 
-	app.Get("/api/groups/:groupID/members", svc.GetGroupMembersHandler)
-	app.Delete("/api/groups/:groupID/members", svc.LeaveGroupHandler)
 	app.Put("/api/groups/:groupID/members/:userID", svc.ModifyGroupMemberHandler)
 	app.Delete("/api/groups/:groupID/members/:userID", svc.KickGroupMemberHandler)
 

--- a/backend/services/frontend/main.go
+++ b/backend/services/frontend/main.go
@@ -116,17 +116,17 @@ func main() {
 	app.Put("/api/groups/:groupID", svc.ModifyGroupHandler)
 	app.Delete("/api/groups/:groupID", svc.DeleteGroupHandler)
 
-	app.Get("/api/groups/:groupID/members", svc.GetGroupMembersHandler)
-	app.Delete("/api/groups/:groupID/members", svc.LeaveGroupHandler)
-	app.Put("/api/groups/:groupID/members/:userID", svc.ModifyGroupMemberHandler)
-	app.Delete("/api/groups/:groupID/members/:userID", svc.KickGroupMemberHandler)
 	app.Get("/api/groups/:groupID/members/requests", svc.GetGroupMemberRequestsHandler)
 	app.Get("/api/groups/:groupID/members/invitations", svc.GetInvitationsForGroupHandler)
-
 	app.Post("/api/groups/:groupID/members/invitation", svc.AddUserGroupInviteHandler)
 	app.Delete("/api/groups/:groupID/members/invitation", svc.RemoveUserGroupInviteHandler)
 	app.Post("/api/groups/:groupID/members/request", svc.AddUserGroupRequestHandler)
 	app.Delete("/api/groups/:groupID/members/request", svc.RemoveUserGroupRequestHandler)
+
+	app.Get("/api/groups/:groupID/members", svc.GetGroupMembersHandler)
+	app.Delete("/api/groups/:groupID/members", svc.LeaveGroupHandler)
+	app.Put("/api/groups/:groupID/members/:userID", svc.ModifyGroupMemberHandler)
+	app.Delete("/api/groups/:groupID/members/:userID", svc.KickGroupMemberHandler)
 
 	app.Get("/api/decks/favorites", svc.GetFavoriteDecksHandler)
 	app.Post("/api/decks/favorites", svc.AddFavoriteDeckHandler)


### PR DESCRIPTION
## Description

This PR rearranges the paths in the backend api so the invite/request accept/decline endpoints are not overwritten.

## Resolved Issues
resolves #229