### PR TITLE
fix: remove email logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 private_key.yaml
 .DS_STORE
 frontend/build-storybook.log
+*.pem

--- a/backend/services/user/handler/user.go
+++ b/backend/services/user/handler/user.go
@@ -26,7 +26,6 @@ func New(s store.UserStore, cS pbCollaboration.CollaborationService) *User {
 }
 
 func (e *User) Register(ctx context.Context, req *pbCommon.User, rsp *pbCommon.Success) error {
-	logger.Infof("Received User.Register request: email: %v", req.UserEmail)
 	if _, err := e.store.FindUserByEmail(ctx, req.UserEmail); err == nil {
 		return helper.NewMicroUserAlreadyExistsErr(helper.UserServiceID)
 	} else if !errors.Is(err, helper.ErrStoreNoExistingUserWithEmail) {
@@ -117,7 +116,6 @@ func (e *User) DeleteUser(ctx context.Context, req *pbCommon.User, rsp *pbCommon
 }
 
 func (e *User) Login(ctx context.Context, req *pbCommon.User, rsp *pbCommon.User) error {
-	logger.Infof("Received User.Login request: email: %v", req.UserEmail)
 	user, err := e.store.FindUserByEmail(ctx, req.UserEmail)
 	if err != nil {
 		if errors.Is(err, helper.ErrStoreNoExistingUserWithEmail) {
@@ -136,7 +134,6 @@ func (e *User) Login(ctx context.Context, req *pbCommon.User, rsp *pbCommon.User
 }
 
 func (e *User) GetUserIDFromEmail(ctx context.Context, req *pbCommon.User, rsp *pbCommon.User) error {
-	logger.Infof("Received User.GetUserIDFromEmail request: %v", req)
 	user, err := e.store.FindUserByEmail(ctx, req.UserEmail)
 	if err != nil {
 		if errors.Is(err, helper.ErrStoreNoExistingUserWithEmail) {

--- a/backend/store/postgres.go
+++ b/backend/store/postgres.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/kioku-project/kioku/pkg/helper"
 	"go.opentelemetry.io/otel"
@@ -43,9 +42,9 @@ func NewPostgresStore(ctx context.Context) (*gorm.DB, error) {
 	logger := logger.New(
 		logrus.NewWriter(),
 		logger.Config{
-			SlowThreshold: time.Millisecond,
-			LogLevel:      logger.Warn,
-			Colorful:      false,
+			LogLevel:                  logger.Silent,
+			Colorful:                  false,
+			IgnoreRecordNotFoundError: true,
 		},
 	)
 


### PR DESCRIPTION
# Description

This PR removes logging of emails in the `user` service, as well mutes the GORM logger.
This may lead to the fact that our tracing architecture may have consequences, but this is definitely a step towards compliance.

## Resolved Issues

resolves #237 
