### PR TITLE
Adjust tabs for mobile devices

### DIFF
--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -73,7 +73,7 @@ export const Header = ({
 
 	return (
 		<div
-			className={`flex flex-row items-center justify-between ${className}`}
+			className={`flex flex-row items-center justify-between px-5 md:px-10 ${className}`}
 			{...props}
 		>
 			<div className="flex flex-col font-black">

--- a/frontend/components/navigation/Tabs/TabBar.tsx
+++ b/frontend/components/navigation/Tabs/TabBar.tsx
@@ -1,6 +1,8 @@
+import clsx from "clsx";
 import React, { ReactNode } from "react";
 
 import { Text } from "@/components/Text";
+import { OperatingSystem, getOperatingSystem } from "@/util/client";
 
 interface TabBarProps {
 	/**
@@ -35,21 +37,29 @@ export const TabBar = ({
 	className = "",
 	...props
 }: TabBarProps) => {
+	const os = getOperatingSystem(navigator.userAgent);
+
 	return (
 		<div
-			className={`flex flex-row justify-between ${className}`}
+			className={`flex flex-row justify-between md:px-10 ${className}`}
 			{...props}
 		>
-			<div className="flex w-full flex-row md:relative">
+			<div
+				className={clsx(
+					"flex w-full flex-row md:relative md:border-0 md:pb-0",
+					os === OperatingSystem.IOS && "pb-3"
+				)}
+			>
 				{Object.keys(tabs).map((tab) => (
 					<Text
 						textSize="xs"
 						key={tab}
-						className={`flex-1 cursor-pointer border-kiokuDarkBlue p-3 font-bold transition md:flex-initial ${
+						className={clsx(
+							"flex-1 cursor-pointer border-t-2 p-3 font-bold transition md:flex-initial md:border-t-0",
 							currentTab === tab
-								? "border-b-2 text-kiokuDarkBlue"
-								: "border-none text-kiokuLightBlue"
-						}`}
+								? " border-kiokuDarkBlue text-kiokuDarkBlue md:border-b-2"
+								: "border-kiokuLightBlue text-kiokuLightBlue"
+						)}
 						onClick={() => {
 							setTab(tab);
 						}}

--- a/frontend/components/navigation/Tabs/TabBar.tsx
+++ b/frontend/components/navigation/Tabs/TabBar.tsx
@@ -57,7 +57,7 @@ export const TabBar = ({
 						className={clsx(
 							"flex-1 cursor-pointer border-t-2 p-3 font-bold transition md:flex-initial md:border-t-0",
 							currentTab === tab
-								? " border-kiokuDarkBlue text-kiokuDarkBlue md:border-b-2"
+								? "border-kiokuDarkBlue text-kiokuDarkBlue md:border-b-2"
 								: "border-kiokuLightBlue text-kiokuLightBlue"
 						)}
 						onClick={() => {

--- a/frontend/components/navigation/Tabs/TabHeader.tsx
+++ b/frontend/components/navigation/Tabs/TabHeader.tsx
@@ -35,12 +35,12 @@ export const TabHeader = ({
 }: TabHeaderProps) => {
 	return (
 		<div
-			className={`flex flex-row items-center justify-center space-x-2 ${className}`}
+			className={`flex flex-col items-center justify-center sm:flex-row sm:space-x-2 ${className}`}
 			{...props}
 		>
 			<Icon icon={icon} />
 
-			<div className="hidden sm:flex">{name}</div>
+			<div>{name}</div>
 			{notificationBadgeContent && (
 				<div className="relative flex h-full text-sm text-eggshell">
 					<div className="absolute inline-flex h-full w-full animate-[ping_1s_ease-out_3] rounded-full bg-kiokuRed opacity-75" />

--- a/frontend/pages/deck/[id]/index.tsx
+++ b/frontend/pages/deck/[id]/index.tsx
@@ -68,7 +68,7 @@ export default function Page() {
 
 			<div className="min-w-screen flex flex-1 flex-col overflow-auto bg-eggshell">
 				{group && deck && (
-					<div className="flex h-full flex-col px-5 py-1 md:space-y-5 md:px-10 md:py-3">
+					<div className="flex h-full flex-col md:space-y-5">
 						<FetchHeader
 							id={"deckPageHeaderId"}
 							group={group}
@@ -81,7 +81,7 @@ export default function Page() {
 								currentTab={currentTab}
 								setTab={setCurrentTab}
 							/>
-							<div className="overflow-auto">
+							<div className="overflow-auto px-5 md:px-10">
 								{{
 									cards: (
 										<CardsTab

--- a/frontend/pages/group/[id]/index.tsx
+++ b/frontend/pages/group/[id]/index.tsx
@@ -77,7 +77,7 @@ export default function Page() {
 
 			<div className="min-w-screen flex flex-1 flex-col bg-eggshell">
 				{group && (
-					<div className="flex h-full flex-col px-5 py-1 md:space-y-5 md:px-10 md:py-3">
+					<div className="flex h-full flex-col md:space-y-5">
 						<FetchHeader id="groupPageHeaderId" group={group} />
 						<div className="flex h-full flex-1 flex-col-reverse justify-between space-y-5 overflow-auto md:flex-col md:justify-normal">
 							<TabBar
@@ -86,7 +86,7 @@ export default function Page() {
 								currentTab={currentTab}
 								setTab={setCurrentTab}
 							/>
-							<div className="overflow-auto">
+							<div className="overflow-auto px-5 md:px-10">
 								{{
 									decks: <DecksTab group={group} />,
 									user: <MembersTab group={group} />,

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
 			</Head>
 			<div className="min-w-screen flex flex-1 flex-col bg-eggshell">
 				{user && groups && (
-					<div className="flex h-full flex-col px-5 py-1 md:space-y-5 md:px-10 md:py-3">
+					<div className="flex h-full flex-col md:space-y-5">
 						<FetchHeader
 							id="userPageHeaderId"
 							user={{ ...user, ...due }}
@@ -99,7 +99,7 @@ export default function Home() {
 								currentTab={currentTab}
 								setTab={setCurrentTab}
 							/>
-							<div className="overflow-auto">
+							<div className="overflow-auto px-5 md:px-10">
 								{{
 									decks: homeGroup && (
 										<DecksTab group={homeGroup} />


### PR DESCRIPTION
## Description

This pr quickfixes the tabbar on mobile devices. Especially it adds space on the bottom on iOS devices to display the navigation slider. Please note that the tabbar needs a refactoring and other aspects will be addressed in a future pr.

![Simulator Screenshot - myiPhone 15 Pro Max - 2024-02-13 at 21 40 39](https://github.com/kioku-project/kioku/assets/66846059/80d185ee-a5cd-4751-be26-ed5e0f1ef682)
