### PR TITLE
Add environment variables to pg_isready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U kioku"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Description

This PR resolves fatal DB logs when the provided env variables `POSTGRES_USER` and `POSTGRES_DB` are not set to `kioku`.