### PR TITLE
Enable local Kubernetes deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+kind-up:
+	./hacks/kind-up.sh
+
+deploy:
+	./hacks/deploy.sh
+
+kind-deploy:
+	docker compose -f ./docker-compose.build.yml build
+	kind load docker-image kioku-frontend:latest kioku-carddeck_service:latest kioku-frontend_proxy:latest kioku-srs_service:latest kioku-user_service:latest kioku-collaboration_service:latest kioku-notification_service:latest
+	./hacks/deploy.sh ./hacks/values_local.yaml

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,50 @@
+version: "3"
+
+services:
+  frontend_proxy:
+    container_name: kioku-frontend_proxy
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/frontend/Dockerfile
+
+  user_service:
+    container_name: kioku-user_service
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/user/Dockerfile
+
+  carddeck_service:
+    container_name: kioku-carddeck_service
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/carddeck/Dockerfile
+
+  collaboration_service:
+    container_name: kioku-collaboration_service
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/collaboration/Dockerfile
+
+  srs_service:
+    container_name: kioku-srs_service
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/srs/Dockerfile
+
+  notification_service:
+    container_name: kioku-notification_service
+    restart: always
+    build:
+      context: backend
+      dockerfile: services/notification/Dockerfile
+
+  frontend:
+    container_name: kioku-frontend
+    restart: always
+    build:
+      context: frontend

--- a/hacks/deploy.sh
+++ b/hacks/deploy.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# This script allows to deploy kioku to an external Kubernetes cluster
+# This script allows to deploy kioku to a Kubernetes cluster
 # Assumptions:
 #   - KUBECONFIG already targets the cluster
-#   - Script is executed from kioku-repo root folder
+VALUE_STRING=""
+if ! [ -z "$1" ]; then
+  VALUE_STRING="-f $1"
+  echo "$1"
+fi
 
 # Get dependent repositories
 helm repo add postgres-operator-charts https://opensource.zalando.com/postgres-operator/charts/postgres-operator
@@ -19,4 +23,4 @@ helm install postgres-operator postgres-operator-charts/postgres-operator
 #   --create-namespace
 
 # Install Kioku
-helm install kioku helm/kioku
+helm upgrade --install kioku helm/kioku $VALUE_STRING

--- a/hacks/kind-up.sh
+++ b/hacks/kind-up.sh
@@ -1,0 +1,21 @@
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml

--- a/hacks/values_local.yaml
+++ b/hacks/values_local.yaml
@@ -1,4 +1,4 @@
-mode: production
+mode: latestuction
 
 vapidSecret: vapid-secret
 
@@ -22,8 +22,8 @@ database:
 
 frontend:
   name: kioku-frontend
-  image: ghcr.io/kioku-project/kioku_frontend
-  tag: prod
+  image: kioku-frontend
+  tag: latest
   port: 80
   containerPort: 3000
 
@@ -36,8 +36,8 @@ frontend:
 
 frontend_proxy:
   name: kioku-frontend-proxy
-  image: ghcr.io/kioku-project/kioku_frontend_proxy
-  tag: prod
+  image: kioku-frontend_proxy
+  tag: latest
   httpPath: /api
 
   keySecret: frontend-proxy-key-secret
@@ -52,8 +52,8 @@ frontend_proxy:
 
 carddeck:
   name: kioku-carddeck
-  image: ghcr.io/kioku-project/kioku_carddeck
-  tag: prod
+  image: kioku-carddeck_service
+  tag: latest
 
   autoscaler:
     min: 1
@@ -62,8 +62,8 @@ carddeck:
 
 srs:
   name: kioku-srs
-  image: ghcr.io/kioku-project/kioku_srs
-  tag: prod
+  image: kioku-srs_service
+  tag: latest
 
   autoscaler:
     min: 1
@@ -72,8 +72,8 @@ srs:
 
 notification:
   name: kioku-notification
-  image: ghcr.io/kioku-project/kioku_notification
-  tag: prod
+  image: kioku-notification_service
+  tag: latest
 
   autoscaler:
     min: 1
@@ -82,8 +82,8 @@ notification:
 
 user:
   name: kioku-user
-  image: ghcr.io/kioku-project/kioku_user
-  tag: prod
+  image: kioku-user_service
+  tag: latest
 
   autoscaler:
     min: 1
@@ -92,8 +92,8 @@ user:
 
 collaboration:
   name: kioku-collaboration
-  image: ghcr.io/kioku-project/kioku_collaboration
-  tag: prod
+  image: kioku-collaboration_service
+  tag: latest
 
   autoscaler:
     min: 1


### PR DESCRIPTION
## Description

With this PR, a `Makefile` is introduced, with which it becomes easily possible to deploy Kioku in a local kind cluster.
It is also possible to start this cluster with the correct configuration.

After running

`make kind-up`
`make kind-deploy`

Kioku becomes available under `localhost`
