### PR TITLE
optimize k8s-deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 kind-up:
 	./hacks/kind-up.sh
 
+kind-down:
+	kind delete cluster --name kioku
+
 deploy:
 	./hacks/deploy.sh
 
 kind-deploy:
 	docker compose -f ./docker-compose.build.yml build
-	kind load docker-image kioku-frontend:latest kioku-carddeck_service:latest kioku-frontend_proxy:latest kioku-srs_service:latest kioku-user_service:latest kioku-collaboration_service:latest kioku-notification_service:latest
+	kind load --name kioku docker-image kioku-frontend:latest kioku-carddeck_service:latest kioku-frontend_proxy:latest kioku-srs_service:latest kioku-user_service:latest kioku-collaboration_service:latest kioku-notification_service:latest
 	./hacks/deploy.sh ./hacks/values_local.yaml

--- a/hacks/kind-up.sh
+++ b/hacks/kind-up.sh
@@ -1,4 +1,4 @@
-cat <<EOF | kind create cluster --config=-
+cat <<EOF | kind create cluster --name kioku --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/hacks/values_local.yaml
+++ b/hacks/values_local.yaml
@@ -2,6 +2,10 @@ mode: latestuction
 
 vapidSecret: vapid-secret
 
+ingress:
+  enabled: true
+  hostname: "*"
+
 cassandra:
   username: cassandra
   password: cassandra
@@ -30,9 +34,10 @@ frontend:
   httpPath: /
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 frontend_proxy:
   name: kioku-frontend-proxy
@@ -46,9 +51,10 @@ frontend_proxy:
   containerPort: 8090
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 carddeck:
   name: kioku-carddeck
@@ -56,9 +62,10 @@ carddeck:
   tag: latest
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 srs:
   name: kioku-srs
@@ -66,9 +73,10 @@ srs:
   tag: latest
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 notification:
   name: kioku-notification
@@ -76,9 +84,10 @@ notification:
   tag: latest
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 user:
   name: kioku-user
@@ -86,9 +95,10 @@ user:
   tag: latest
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 collaboration:
   name: kioku-collaboration
@@ -96,6 +106,7 @@ collaboration:
   tag: latest
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100

--- a/helm/kioku/templates/carddeck.yaml
+++ b/helm/kioku/templates/carddeck.yaml
@@ -26,13 +26,12 @@ spec:
       {{ end }}
         ports:
           - containerPort: 8080
+      {{ if .Values.carddeck.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         env:
           - name: HOSTNAME
             valueFrom:
@@ -64,6 +63,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+
+{{- if .Values.carddeck.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -77,3 +78,4 @@ spec:
  minReplicas: {{ .Values.carddeck.autoscaler.min }}
  maxReplicas: {{ .Values.carddeck.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.carddeck.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/cassandra_secret.example.yaml
+++ b/helm/kioku/templates/cassandra_secret.example.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cassandra-secret
-  namespace: monitoring
   labels:
     {{- include "kioku.labels" . | nindent 4 }}
 type: Opaque

--- a/helm/kioku/templates/collaboration.yaml
+++ b/helm/kioku/templates/collaboration.yaml
@@ -26,13 +26,12 @@ spec:
       {{ end }}
         ports:
           - containerPort: 8080
+      {{ if .Values.collaboration.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         env:
           - name: HOSTNAME
             valueFrom:
@@ -63,6 +62,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+
+{{- if .Values.collaboration.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -76,3 +77,4 @@ spec:
  minReplicas: {{ .Values.collaboration.autoscaler.min }}
  maxReplicas: {{ .Values.collaboration.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.collaboration.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/frontend.yaml
+++ b/helm/kioku/templates/frontend.yaml
@@ -25,11 +25,11 @@ spec:
       {{ end }}
         ports:
         - containerPort: {{ .Values.frontend.port }}
+      {{ if .Values.frontend.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
-          requests:
-            cpu: 200m
+      {{ end }}
         env:
           # TODO: Export to values.yaml
           - name: NEXT_PUBLIC_ENVIRONMENT
@@ -49,7 +49,8 @@ spec:
   ports:
     - port: {{ .Values.frontend.port }}
       targetPort: {{ .Values.frontend.containerPort }}
-  type: LoadBalancer
+  type: ClusterIP
+{{- if .Values.frontend.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -63,3 +64,4 @@ spec:
  minReplicas: {{ .Values.frontend.autoscaler.min }}
  maxReplicas: {{ .Values.frontend.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.frontend.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/frontend_proxy.yaml
+++ b/helm/kioku/templates/frontend_proxy.yaml
@@ -30,13 +30,12 @@ spec:
         ports:
         - containerPort: {{ .Values.frontend_proxy.containerPort }}
           protocol: TCP
+      {{ if .Values.frontend_proxy.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         envFrom:
           - configMapRef:
               name: service-env
@@ -57,7 +56,9 @@ spec:
   ports:
     - port: {{ .Values.frontend_proxy.port }}
       targetPort: {{ .Values.frontend_proxy.containerPort }}
-  type: LoadBalancer
+  type: ClusterIP
+
+{{- if .Values.frontend_proxy.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -71,3 +72,4 @@ spec:
  minReplicas: {{ .Values.frontend_proxy.autoscaler.min }}
  maxReplicas: {{ .Values.frontend_proxy.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.frontend_proxy.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/ingress.yaml
+++ b/helm/kioku/templates/ingress.yaml
@@ -1,15 +1,13 @@
+{{- if .Values.ingress.enabled -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: endpoint-ingress
-  labels:
-    app: nginx
-  annotations:
-    #nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-    - http:
+    - host: {{ .Values.ingress.hostname }}
+      http:
         paths:
           - path: {{ .Values.frontend.httpPath }}
             pathType: Prefix
@@ -25,3 +23,4 @@ spec:
                 name: "{{ .Values.frontend_proxy.name }}-service"
                 port:
                   number: {{ .Values.frontend_proxy.port }}
+{{- end }}

--- a/helm/kioku/templates/jaeger.yaml
+++ b/helm/kioku/templates/jaeger.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-deployment
-  namespace: monitoring
   labels:
     app: jaeger
 spec:
@@ -48,7 +47,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: jaeger-configmap
-  namespace: monitoring
 data:
   METRICS_STORAGE_TYPE: prometheus
   PROMETHEUS_SERVER_URL: http://prometheus-service.monitoring.svc.cluster.local:9090
@@ -58,7 +56,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: jaeger-configmap-files
-  namespace: monitoring
 data:
   jaeger-ui.json: |-
     {
@@ -117,7 +114,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: otelcol-deployment
-  namespace: monitoring
   labels:
     app: otelcol
 spec:
@@ -154,7 +150,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: otelcol-service
-  namespace: monitoring
 spec:
   selector: 
     app: otelcol
@@ -173,7 +168,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jaeger-service
-  namespace: monitoring
 spec:
   selector: 
     app: jaeger
@@ -192,10 +186,3 @@ metadata:
 data:
   TRACING_ENABLED: "true"
   TRACING_COLLECTOR: "otelcol-service.monitoring.svc.cluster.local:4318"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: monitoring
-  labels:
-    name: monitoring

--- a/helm/kioku/templates/notification.yaml
+++ b/helm/kioku/templates/notification.yaml
@@ -26,13 +26,12 @@ spec:
       {{ end }}
         ports:
           - containerPort: 8080
+      {{ if .Values.notification.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         env:
           - name: HOSTNAME
             valueFrom:
@@ -66,6 +65,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+
+{{- if .Values.notification.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -79,3 +80,4 @@ spec:
  minReplicas: {{ .Values.notification.autoscaler.min }}
  maxReplicas: {{ .Values.notification.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.notification.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/prometheus.yaml
+++ b/helm/kioku/templates/prometheus.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-deployment
-  namespace: monitoring
   labels:
     app: prometheus-server
 spec:
@@ -50,7 +49,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-service
-  namespace: monitoring
   annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port:   '9090'
@@ -67,7 +65,6 @@ metadata:
   name: prometheus-server-conf
   labels:
     name: prometheus-server-conf
-  namespace: monitoring
 data:
   prometheus.rules: ""
   prometheus.yml: |-
@@ -218,4 +215,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: monitoring
+  namespace: {{ .Release.Namespace }}

--- a/helm/kioku/templates/srs.yaml
+++ b/helm/kioku/templates/srs.yaml
@@ -26,13 +26,12 @@ spec:
       {{ end }}
         ports:
           - containerPort: 8080
+      {{ if .Values.srs.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         env:
           - name: HOSTNAME
             valueFrom:
@@ -64,6 +63,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+
+{{- if .Values.srs.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -77,3 +78,4 @@ spec:
  minReplicas: {{ .Values.srs.autoscaler.min }}
  maxReplicas: {{ .Values.srs.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.srs.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/templates/user.yaml
+++ b/helm/kioku/templates/user.yaml
@@ -26,13 +26,12 @@ spec:
       {{ end }}
         ports:
           - containerPort: 8080
+      {{ if .Values.user.autoscaler.enabled }}
         resources:
           limits:
             cpu: 500m
             memory: 500M
-          requests:
-            cpu: 50m
-            memory: 50M
+      {{ end }}
         env:
           - name: HOSTNAME
             valueFrom:
@@ -63,6 +62,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+
+{{- if .Values.user.autoscaler.enabled -}}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -76,3 +77,4 @@ spec:
  minReplicas: {{ .Values.user.autoscaler.min }}
  maxReplicas: {{ .Values.user.autoscaler.max }}
  targetCPUUtilizationPercentage: {{ .Values.user.autoscaler.targetCPUUtilizationPercentage }}
+{{- end -}}

--- a/helm/kioku/values.yaml
+++ b/helm/kioku/values.yaml
@@ -2,6 +2,10 @@ mode: production
 
 vapidSecret: vapid-secret
 
+ingress:
+  enabled: true
+  hostname: "*"
+
 cassandra:
   username: cassandra
   password: cassandra
@@ -30,9 +34,10 @@ frontend:
   httpPath: /
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 frontend_proxy:
   name: kioku-frontend-proxy
@@ -46,9 +51,10 @@ frontend_proxy:
   containerPort: 8090
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 carddeck:
   name: kioku-carddeck
@@ -56,9 +62,10 @@ carddeck:
   tag: prod
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 srs:
   name: kioku-srs
@@ -66,9 +73,10 @@ srs:
   tag: prod
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 notification:
   name: kioku-notification
@@ -76,9 +84,10 @@ notification:
   tag: prod
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 user:
   name: kioku-user
@@ -86,9 +95,10 @@ user:
   tag: prod
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100
 
 collaboration:
   name: kioku-collaboration
@@ -96,6 +106,7 @@ collaboration:
   tag: prod
 
   autoscaler:
+    enabled: false
     min: 1
     max: 10
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 100


### PR DESCRIPTION
# Description

This PR modifies the local k8s deployment.
In addition to that, it also adds the possibility to toggle the deployment of `Ingress` and `HorizontalPodAutoScaler` resources

## Resolved Issues

part of #270 
