### PR TITLE
Implement proper push notification token deletion

### DIFF
--- a/backend/services/notification/handler/notification.go
+++ b/backend/services/notification/handler/notification.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"strings"
 
 	"github.com/kioku-project/kioku/pkg/converter"
 	"github.com/kioku-project/kioku/pkg/helper"
@@ -71,6 +72,11 @@ func (e *Notification) Unsubscribe(ctx context.Context, req *pbCommon.PushSubscr
 	}
 	if subscription.UserID != req.UserID {
 		return helper.NewMicroNotAuthorizedErr(helper.NotificationServiceID)
+	}
+
+	// Check if the request is coming from the PWA uninstall event
+	if strings.Contains(req.Subscription.Endpoint, "PWA_UNINSTALL") {
+		logger.Infof("Received PWA uninstall event for subscription: %v", req.Subscription.SubscriptionID)
 	}
 
 	if err := e.store.DeletePushSubscription(ctx, subscription); err != nil {

--- a/frontend/public/service.js
+++ b/frontend/public/service.js
@@ -16,3 +16,22 @@ const showLocalNotification = async (title, options, registration) => {
 		icon: "/kioku-logo.png",
 	});
 };
+
+self.addEventListener("beforeunload", async (event) => {
+	const subscription = await self.registration.pushManager.getSubscription();
+	if (subscription) {
+		await unsubscribe(subscription);
+	}
+});
+
+const unsubscribe = async (subscription) => {
+	const response = await fetch("/api/user/notification/" + subscription.endpoint, {
+		method: "DELETE",
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+	if (!response.ok) {
+		console.error("Failed to unsubscribe:", response.statusText);
+	}
+};


### PR DESCRIPTION
Related to #290

Implement proper push notification token deletion during PWA uninstall.

* **frontend/public/service.js**
  - Add an event listener for the `beforeunload` event to handle PWA uninstall.
  - Call the `unsubscribe` function to delete the push notification token during PWA uninstall.
  - Define the `unsubscribe` function to send a DELETE request to the server to remove the push notification token.

* **backend/services/notification/handler/notification.go**
  - Update the `Unsubscribe` function to handle token deletion during PWA uninstall.
  - Add a check to verify if the request is coming from the PWA uninstall event by checking the subscription endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kioku-project/kioku/issues/290?shareId=a853ef86-93eb-493b-a112-42556ac0c48b).